### PR TITLE
Исправление ошибки при получении баланса доп. карт

### DIFF
--- a/providers/ab-money-belarusbank/main.js
+++ b/providers/ab-money-belarusbank/main.js
@@ -178,7 +178,7 @@ function fetchCard(baseurl, html){
     	//Надо заново получить всё.
     	var cardId = getParam(info.card, /<td[^>]+class="tdId"[^>]*>([\s\S]*?)<\/td>/i, replaceTagsAndSpaces);
     	var form = getParam(html, /<form[^>]+id="[^"]*:ClientCardsDataForm"[^>]*>[\s\S]*?<\/form>/i);
-    	var action = getParam(form, /<form[^>]+action="([^"]*)/i, replaceHtmlEntities);
+    	var action = getParam(form, /<form[^>]+action="([^"#]*)/i, replaceHtmlEntities);
 		var params = createFormParams(form, function(params, str, name, value) {
 			if (/acctIdSelField/i.test(name) || name == 'accountNumber') 
 				return info.accnum;


### PR DESCRIPTION
Не работает получение баланса по дополнительной карте http://support.anybalance.ru/tickets.php?id=18632
Так как сайт интернет-банкинга не понимает посланный ему функцией AnyBalance.requestPost символ '#', то предлагаю исключить этот якорь из URL.
После этого изменения получение баланса по дополнительной карте проходит корректно.